### PR TITLE
add regexp delimiters to the step definition text

### DIFF
--- a/behave/matchers.py
+++ b/behave/matchers.py
@@ -133,7 +133,7 @@ def register_type(**kw):
 class RegexMatcher(Matcher):
     def __init__(self, func, string, step_type=None):
         super(RegexMatcher, self).__init__(func, string, step_type)
-        self.regex = re.compile(self.string)
+        self.regex = re.compile("^{0}$".format(self.string))
 
     def check_match(self, step):
         m = self.regex.match(step)


### PR DESCRIPTION
To prevent AmbiguousStep errors from being thrown when having defined steps starting with the same string regexp start and end delimiters are added to the step definition text. This way the regex matcher matches step definition text as full string and not onle at the beginning of it.
